### PR TITLE
[FIX] 새로운 프론트 도메인 CORS 허용

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/config/CorsConfig.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/CorsConfig.java
@@ -16,6 +16,7 @@ public class CorsConfig {
             public void addCorsMappings(@NonNull CorsRegistry registry) {
                 registry.addMapping("/**")
                         .allowedOrigins("http://localhost:3000", "https://gdgocinha.com",
+                                "https://www.gdgocinha.com",
                                 "https://typing-game-alpha-umber.vercel.app")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")


### PR DESCRIPTION
### 📌 연관된 이슈
#46


### ✨ 작업 내용
기존 프론트 도메인에 www 붙는 도메인도 사용할 수 있도록 하여 이를 CORS 허용하였습니다.


### 💬 리뷰 요구사항(선택)
