### PR TITLE
[FIX] 인증 필요 없는 부분 빼고 인증할 수 있도록 변경

### DIFF
--- a/gdgoc/src/main/java/inha/gdgoc/config/SecurityConfig.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package inha.gdgoc.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/test/**",
+                                "/game/**",
+                                "/apply/**",
+                                "/check/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
oauth 관련 라이브러리 import 하는 바람에 모든 api에 기본적으로 인증해야 되도록 설정되어서 인증이 필요 없는 부분은 안 하도록 변경


### 💬 리뷰 요구사항(선택)
