### PR TITLE
[FIX] .env 파일을 컨테이너 내부에 복사

### DIFF
--- a/gdgoc/deploy.sh
+++ b/gdgoc/deploy.sh
@@ -31,5 +31,8 @@ docker volume prune -f
 export $(grep -v '^#' .env | xargs)
 docker pull ${DOCKER_HUB_USERNAME}/gdgoc-be-app:latest
 
+# 컨테이너 내부로 `.env` 파일을 복사하는 명령 추가
+docker run --rm -v /home/ubuntu/gdgoc-be-app/.env:/app/.env ${DOCKER_HUB_USERNAME}/gdgoc-be-app:latest sh -c "cat /app/.env"
+
 # 컨테이너 실행
-docker-compose --env-file /home/ubuntu/gdgoc-be-app/.env up -d
+docker-compose --env-file .env up -d

--- a/gdgoc/deploy.sh
+++ b/gdgoc/deploy.sh
@@ -32,4 +32,4 @@ export $(grep -v '^#' .env | xargs)
 docker pull ${DOCKER_HUB_USERNAME}/gdgoc-be-app:latest
 
 # 컨테이너 실행
-docker-compose --env-file .env up -d
+docker-compose --env-file /home/ubuntu/gdgoc-be-app/.env up -d

--- a/gdgoc/docker-compose.yml
+++ b/gdgoc/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       SPRING_DATASOURCE_USERNAME: "${DB_USERNAME}"
       SPRING_DATASOURCE_PASSWORD: "${DB_PASSWORD}"
     env_file:
-      - .env
+      - /home/ubuntu/gdgoc-be-app/.env

--- a/gdgoc/docker-compose.yml
+++ b/gdgoc/docker-compose.yml
@@ -12,5 +12,5 @@ services:
       SPRING_DATASOURCE_URL: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}"
       SPRING_DATASOURCE_USERNAME: "${DB_USERNAME}"
       SPRING_DATASOURCE_PASSWORD: "${DB_PASSWORD}"
-    env_file:
-      - /home/ubuntu/gdgoc-be-app/.env
+    volumes:
+      - /home/ubuntu/gdgoc-be-app/.env:/app/.env

--- a/gdgoc/src/main/java/inha/gdgoc/config/DotenvLoader.java
+++ b/gdgoc/src/main/java/inha/gdgoc/config/DotenvLoader.java
@@ -10,9 +10,7 @@ public class DotenvLoader {
     @PostConstruct
     public void loadEnv() {
         try {
-            Dotenv dotenv = Dotenv.configure()
-                    .directory("/home/ubuntu/gdgoc-be-app")  // .env 파일 디렉토리 명시
-                    .load();
+            Dotenv dotenv = Dotenv.load();
             System.setProperty("GOOGLE_CLIENT_ID", dotenv.get("GOOGLE_CLIENT_ID"));
             System.setProperty("GOOGLE_CLIENT_SECRET", dotenv.get("GOOGLE_CLIENT_SECRET"));
             System.setProperty("GOOGLE_REDIRECT_URI", dotenv.get("GOOGLE_REDIRECT_URI"));


### PR DESCRIPTION
### 📌 연관된 이슈
#5


### ✨ 작업 내용
.env 파일이 우분투에는 있는데 컨테이너 안에 없어서 코드에서 못 읽는 것 같아 복사했습니다.


### 💬 리뷰 요구사항(선택)
